### PR TITLE
add user interests to db

### DIFF
--- a/backend/prisma/migrations/20240705205627_add_interests/migration.sql
+++ b/backend/prisma/migrations/20240705205627_add_interests/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `cuisines` on the `User` table. All the data in the column will be lost.
+  - You are about to drop the column `hobbies` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "cuisines",
+DROP COLUMN "hobbies",
+ADD COLUMN     "interests" TEXT[];

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -8,7 +8,6 @@ datasource db {
 }
 
 model User {
-  id       String   @id
-  hobbies  String[]
-  cuisines String[]
+  id        String   @id
+  interests String[]
 }

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -45,28 +45,14 @@ router.delete("/:id", async (req, res) => {
   res.status(204).json(deletedUser);
 });
 
-router.put("/:id/hobby", async (req, res) => {
+router.put("/:id/interest", async (req, res) => {
   const user = await prisma.user.update({
     where: {
       id: req.params.id,
     },
     data: {
-      hobbies: {
-        push: req.body.hobby,
-      },
-    },
-  });
-  res.status(204).json(user);
-});
-
-router.put("/:id/cuisine", async (req, res) => {
-  const user = await prisma.user.update({
-    where: {
-      id: req.params.id,
-    },
-    data: {
-      cuisines: {
-        push: req.body.cuisine,
+      interests: {
+        push: req.body.interest,
       },
     },
   });


### PR DESCRIPTION
## Description
Removes `hobbies` and `cuisines` field that were used for testing initially and adds an `interests` field to the User model within Prisma.
Updates the Express API endpoints used to PUT a new interest to a user.
This PR is part of the setup for integrating the recommendation system with the rest of the application.

#Resources
[Prisma scalar list CRUD documentation](https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/working-with-scalar-lists-arrays)