### PR TITLE
compute route matrix

### DIFF
--- a/backend/routes/googleAPI.js
+++ b/backend/routes/googleAPI.js
@@ -19,6 +19,18 @@ router.get("/computeRoute", async (req, res) => {
   }
 });
 
+router.get("/computeRouteMatrix", async (req, res) => {
+  try {
+    const data = await utils.fetchRouteMatrix(
+      req.query.originAddress,
+      req.query.destinationAddresses
+    );
+    res.status(200).send(data);
+  } catch (error) {
+    res.status(500);
+  }
+});
+
 router.get("/nearbyPlaces", async (req, res) => {
   try {
     const data = await utils.fetchPlaces(


### PR DESCRIPTION
## Description
Implements the Google Routes computeRouteMatrix endpoint in place of the Google Routes computeRoutes endpoint. This step was necessary for the transition to implementing the recommendation system with the rest of the app. During the development process before this change, I was using the computeRoutes endpoint because it gave me the most flexibility with how to fetch the data (individually instead of all destinations at once). 

However, now I only need to get the route duration and fare for the recommendation system, which the RouteMatrix provides, and I can fetch the routes' polylines separately and as needed with the computeRoutes endpoint once the recommendation ranking is completed.

## Resources
[Route Matrix](https://developers.google.com/maps/documentation/routes/compute_route_matrix)