### PR TITLE
accessibility scoring modifications

### DIFF
--- a/backend/Recommend.js
+++ b/backend/Recommend.js
@@ -40,14 +40,19 @@ async function calculateInterestScores(query, interests, options) {
 }
 
 function calculatePreferenceScores(settings, options) {
-  const { budget, minRating, goodForChildren, goodForGroups, isAccessible } =
-    settings;
+  const {
+    budget,
+    minRating,
+    goodForChildren,
+    goodForGroups,
+    isAccessible: preferAccessible,
+  } = settings;
   const userVector = [
     recommendUtils.biasPreference(budget, true),
     recommendUtils.biasPreference(minRating, false),
-    +goodForChildren,
-    +goodForGroups,
-    +isAccessible,
+    goodForChildren ? 1 : 0,
+    goodForGroups ? 1 : 0,
+    preferAccessible ? 1 : 0,
   ];
 
   const preferenceScores = new Map();
@@ -59,7 +64,7 @@ function calculatePreferenceScores(settings, options) {
       rating,
       goodForChildren ? 1 : 0,
       goodForGroups ? 1 : 0,
-      accessibilityScore,
+      preferAccessible ? accessibilityScore : 0, // disregards accessibility in scoring if user does not care
     ];
     preferenceScores.set(
       option.place.id,


### PR DESCRIPTION
Previously, if a user did not prefer an accessible location, but a location was partially or fully accessible, then the location was penalized in its preferenceScore. However, in reality, most users will not dislike a location because it is accessible.

Therefore, this PR modifies the preferenceScores function so that
- if a user prefers an accessible location, then it will consider the level of accessibility of that location
- if a user does not mark that they prefer an accessible location, then for both the user vector and that option vector, the element corresponding to accessibility will both be 0, and therefore will not be penalized by the similarity metric
