### PR TITLE
normalize calculatePreferenceScores vectors

### DIFF
--- a/backend/Recommend.js
+++ b/backend/Recommend.js
@@ -40,14 +40,19 @@ async function calculateInterestScores(query, interests, options) {
 }
 
 function calculatePreferenceScores(settings, options) {
-  const { budget, minRating, goodForChildren, goodForGroups, isAccessible } =
-    settings;
+  const {
+    budget,
+    minRating,
+    goodForChildren,
+    goodForGroups,
+    isAccessible: preferAccessible,
+  } = settings;
   const userVector = [
     recommendUtils.biasPreference(budget, true),
     recommendUtils.biasPreference(minRating, false),
-    +goodForChildren,
-    +goodForGroups,
-    +isAccessible,
+    goodForChildren ? 1 : 0,
+    goodForGroups ? 1 : 0,
+    preferAccessible ? 1 : 0,
   ];
 
   const preferenceScores = new Map();
@@ -59,7 +64,7 @@ function calculatePreferenceScores(settings, options) {
       rating,
       goodForChildren ? 1 : 0,
       goodForGroups ? 1 : 0,
-      accessibilityScore,
+      preferAccessible ? accessibilityScore : 0, // disregards accessibility in scoring if user does not care
     ];
     preferenceScores.set(
       option.place.id,

--- a/backend/Recommend.js
+++ b/backend/Recommend.js
@@ -48,8 +48,8 @@ function calculatePreferenceScores(settings, options) {
     isAccessible: preferAccessible,
   } = settings;
   const userVector = [
-    recommendUtils.biasPreference(budget, true),
-    recommendUtils.biasPreference(minRating, false),
+    recommendUtils.biasPreference(budget),
+    recommendUtils.biasPreference(minRating),
     goodForChildren ? 1 : 0,
     goodForGroups ? 1 : 0,
     preferAccessible ? 1 : 0,

--- a/backend/Recommend.js
+++ b/backend/Recommend.js
@@ -40,6 +40,7 @@ async function calculateInterestScores(query, interests, options) {
 }
 
 function calculatePreferenceScores(settings, options) {
+  const MAX_POSSIBLE_RATING = 5;
   const {
     budget,
     minRating,
@@ -49,7 +50,7 @@ function calculatePreferenceScores(settings, options) {
   } = settings;
   const userVector = [
     recommendUtils.biasPreference(budget),
-    recommendUtils.biasPreference(minRating),
+    recommendUtils.biasPreference(minRating / MAX_POSSIBLE_RATING),
     goodForChildren ? 1 : 0,
     goodForGroups ? 1 : 0,
     preferAccessible ? 1 : 0,
@@ -61,7 +62,7 @@ function calculatePreferenceScores(settings, options) {
     const { priceLevel, accessibilityScore } = option.extracted;
     const optionVector = [
       priceLevel,
-      rating,
+      rating / MAX_POSSIBLE_RATING,
       goodForChildren ? 1 : 0,
       goodForGroups ? 1 : 0,
       preferAccessible ? accessibilityScore : 0, // disregards accessibility in scoring if user does not care

--- a/backend/Recommend.js
+++ b/backend/Recommend.js
@@ -40,6 +40,7 @@ async function calculateInterestScores(query, interests, options) {
 }
 
 function calculatePreferenceScores(settings, options) {
+  const MAX_POSSIBLE_PRICE_LEVEL = 4;
   const MAX_POSSIBLE_RATING = 5;
   const {
     budget,
@@ -49,8 +50,8 @@ function calculatePreferenceScores(settings, options) {
     isAccessible: preferAccessible,
   } = settings;
   const userVector = [
-    recommendUtils.biasPreference(budget),
-    recommendUtils.biasPreference(minRating / MAX_POSSIBLE_RATING),
+    recommendUtils.biasPreference(budget / MAX_POSSIBLE_PRICE_LEVEL, true),
+    recommendUtils.biasPreference(minRating / MAX_POSSIBLE_RATING, false),
     goodForChildren ? 1 : 0,
     goodForGroups ? 1 : 0,
     preferAccessible ? 1 : 0,
@@ -61,7 +62,7 @@ function calculatePreferenceScores(settings, options) {
     const { rating, goodForChildren, goodForGroups } = option.place;
     const { priceLevel, accessibilityScore } = option.extracted;
     const optionVector = [
-      priceLevel,
+      priceLevel / MAX_POSSIBLE_PRICE_LEVEL,
       rating / MAX_POSSIBLE_RATING,
       goodForChildren ? 1 : 0,
       goodForGroups ? 1 : 0,

--- a/backend/RecommendUtils.js
+++ b/backend/RecommendUtils.js
@@ -135,9 +135,9 @@ async function getAlignedInterests(queryEmbedding, interests, getEmbedding) {
   return nearInterests;
 }
 
-function biasPreference(value) {
-  // pulls input values in (0, 1) upward and pushes values >1 downward
-  return value ** BIAS;
+function biasPreference(value, isDownward) {
+  // takes input values in [0, 1]
+  return isDownward ? value ** (1 / BIAS) : value ** BIAS;
 }
 
 function normalizeScores(scoresMap) {

--- a/backend/RecommendUtils.js
+++ b/backend/RecommendUtils.js
@@ -1,5 +1,5 @@
 const fetchUtils = require("./FetchResultsUtils");
-const { MAX_REFETCH_TRIES } = process.env;
+const { MAX_REFETCH_TRIES, BIAS } = process.env;
 
 async function getTransformer() {
   TransformersApi = Function('return import("@xenova/transformers")')();
@@ -135,9 +135,9 @@ async function getAlignedInterests(queryEmbedding, interests, getEmbedding) {
   return nearInterests;
 }
 
-function biasPreference(value, isDownward) {
-  const BIAS = 0.9;
-  return isDownward ? value ** BIAS : value ** (1 / BIAS);
+function biasPreference(value) {
+  // pulls input values in (0, 1) upward and pushes values >1 downward
+  return value ** BIAS;
 }
 
 function normalizeScores(scoresMap) {


### PR DESCRIPTION
Previously, the values in the user and option vectors in the calculatePreferenceScores function were not normalized before running the similarity calculation. This meant that the price levels / budgets ranged from 0 to 4 and ratings ranged from 0 to 5, while each of the other elements like goodForChildren or preferAccessible were in the range [0,1].

Normalizing these vectors does not change the functionality of this similarity comparison, but instead makes it easier to interpret the value given by the comparison since all values will be in [0,1]. This will make it easier to make improvements and tweaks to this system in the future.