### PR TITLE
persistent auth state between pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,24 +1,33 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { onAuthStateChanged } from "firebase/auth";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 
 import "@mantine/core/styles.css";
 import { MantineProvider } from "@mantine/core";
 
+import { auth } from "./pages/authentication/firebase-config";
 import Home from "./pages/home/Home";
 import Authentication from "./pages/authentication/Authentication";
 
 function App() {
-  const [user, setUser] = useState(null);
+  const [userId, setUserId] = useState(null);
+
+  useEffect(() => {
+    onAuthStateChanged(auth, (currentUser) => {
+      if (currentUser) {
+        setUserId(currentUser.uid);
+      } else {
+        setUserId(null);
+      }
+    });
+  }, []);
 
   return (
     <MantineProvider>
       <Router>
         <Routes>
-          <Route path="/" element={<Home user={user} />} />
-          <Route
-            path="/login"
-            element={<Authentication user={user} setUser={setUser} />}
-          />
+          <Route path="/" element={<Home userId={userId} />} />
+          <Route path="/authenticate" element={<Authentication />} />
         </Routes>
       </Router>
     </MantineProvider>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,15 +1,30 @@
 import { Title, Group, Button, Box } from "@mantine/core";
+import { useNavigate } from "react-router-dom";
 import "./Header.css";
 
 export default function Header() {
+  const navigate = useNavigate();
   return (
     <Box>
       <header id="header">
         <Group id="header-spacing-group">
           <Title order={1}>Matador</Title>
           <Group>
-            <Button variant="default">Log in</Button>
-            <Button>Sign up</Button>
+            <Button
+              onClick={() =>
+                navigate("/authenticate", { state: { isLogin: true } })
+              }
+              variant="default"
+            >
+              Log in
+            </Button>
+            <Button
+              onClick={() =>
+                navigate("/authenticate", { state: { isLogin: false } })
+              }
+            >
+              Sign up
+            </Button>
           </Group>
         </Group>
       </header>

--- a/frontend/src/pages/authentication/Authentication.jsx
+++ b/frontend/src/pages/authentication/Authentication.jsx
@@ -1,13 +1,10 @@
 import { useEffect, useState } from "react";
-import PropTypes from "prop-types";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import {
   createUserWithEmailAndPassword,
-  onAuthStateChanged,
   signInWithEmailAndPassword,
   signOut,
 } from "firebase/auth";
-import { useToggle, upperFirst } from "@mantine/hooks";
 import {
   TextInput,
   PasswordInput,
@@ -20,28 +17,30 @@ import {
 } from "@mantine/core";
 import { auth } from "./firebase-config";
 
-export default function Authentication({ user, setUser }) {
+export default function Authentication() {
   const navigate = useNavigate();
-  const [type, toggle] = useToggle(["login", "register"]);
+  const isLoginPage = useLocation().state?.isLogin;
+
+  const [isLogin, setIsLogin] = useState(true);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
   useEffect(() => {
-    onAuthStateChanged(auth, (currentUser) => {
-      setUser(currentUser);
-    });
+    if (isLoginPage != null) {
+      setIsLogin(isLoginPage);
+    }
   }, []);
 
   async function authenticate() {
     try {
-      if (type === "login") {
+      if (isLogin) {
         await signInWithEmailAndPassword(auth, email, password);
       } else {
         await createUserWithEmailAndPassword(auth, email, password);
       }
       setEmail("");
       setPassword("");
-      navigate("/")
+      navigate("/");
     } catch (error) {
       console.log(error.message);
     }
@@ -81,29 +80,20 @@ export default function Authentication({ user, setUser }) {
               component="button"
               type="button"
               c="dimmed"
-              onClick={() => toggle()}
+              onClick={() => setIsLogin((prev) => !prev)}
               size="xs"
             >
-              {type === "register"
-                ? "Already have an account? Login"
-                : "Don't have an account? Register"}
+              {isLogin
+                ? "Don't have an account? Register"
+                : "Already have an account? Login"}
             </Anchor>
             <Button onClick={authenticate} radius="md">
-              {upperFirst(type)}
+              {isLogin ? "Login" : "Register"}
             </Button>
           </Group>
         </Paper>
       </Container>
-
-      {/* TODO implement login page sign out*/}
-      <h4> User Logged In: </h4>
-      {user?.email}
       <button onClick={logout}> Sign Out </button>
     </div>
   );
 }
-
-Authentication.propTypes = {
-  user: PropTypes.object,
-  setUser: PropTypes.func.isRequired,
-};

--- a/frontend/src/pages/home/Home.jsx
+++ b/frontend/src/pages/home/Home.jsx
@@ -10,7 +10,7 @@ import Search from "./Search";
 import SearchResult from "./SearchResult";
 import "./Home.css";
 
-export default function Home({ user }) {
+export default function Home({ userId }) {
   const {
     VITE_EXPRESS_API,
     VITE_ORIGIN_ADDRESS,
@@ -27,12 +27,12 @@ export default function Home({ user }) {
   const [route, setRoute] = useState(null);
 
   useEffect(() => {
-    if (user != null) fetchProfile(user);
-  }, [user]);
+    if (userId != null) fetchProfile(userId);
+  }, [userId]);
 
-  async function fetchProfile(user) {
+  async function fetchProfile(userId) {
     try {
-      let url = new URL(`user/${user.uid}`, VITE_EXPRESS_API);
+      let url = new URL(`user/${userId}`, VITE_EXPRESS_API);
 
       const response = await fetch(url);
       if (!response.ok) {
@@ -115,5 +115,5 @@ export default function Home({ user }) {
 }
 
 Home.propTypes = {
-  user: PropTypes.object,
+  userId: PropTypes.string,
 };


### PR DESCRIPTION
## Description
- Allows user to stay logged in until they log out, regardless of page refreshes. Previously, Firebase kept the user authorized while they were logged in, regardless of page refreshes. However, user data was lost from state, and not refetched from the Prisma database to get the user's interests data, when the page was refreshed or navigated away from to another page.
- Now, using useEffect in the App file, I've implemented a way for the user profile to always be fetched if a user is logged in. In addition, the user can navigate from the Home page to the auth page without losing the profile data state, by adding routing from the Header buttons to the auth page.