### PR TITLE
recommendations number values

### DIFF
--- a/backend/Recommend.js
+++ b/backend/Recommend.js
@@ -5,6 +5,8 @@ const {
   INTEREST_SCORE_WEIGHT,
   PREFERENCE_SCORE_WEIGHT,
   TRANSIT_SCORE_WEIGHT,
+  MAX_POSSIBLE_PRICE_LEVEL,
+  MAX_POSSIBLE_RATING,
 } = process.env;
 
 async function calculateInterestScores(query, interests, options) {
@@ -40,8 +42,6 @@ async function calculateInterestScores(query, interests, options) {
 }
 
 function calculatePreferenceScores(settings, options) {
-  const MAX_POSSIBLE_PRICE_LEVEL = 4;
-  const MAX_POSSIBLE_RATING = 5;
   const {
     budget,
     minRating,

--- a/backend/RecommendUtils.js
+++ b/backend/RecommendUtils.js
@@ -55,7 +55,11 @@ function openOnArrival(
   openingHours,
   utcOffsetMinutes
 ) {
-  if (openingHours.periods.length < 7) return true; // incomplete hours data should not hurt recommendation rankings
+  // incomplete hours data should not hurt recommendation rankings
+  if (openingHours.periods.length < 7) {
+    // check if >=1 day of the week has missing hours data
+    return true;
+  }
   let arrivalTime = new Date(new Date(departureTime));
   arrivalTime.setSeconds(arrivalTime.getSeconds() + transitDuration);
 


### PR DESCRIPTION
Edits to numerical values used within the recommendation system.
- Moves the max price level / max rating variables used within calculatePreferenceScores into an env file. Related to Murray's code review comment [here](https://github.com/Andrew-Chu-MetaU-Engineering/matador/pull/19#discussion_r1669049831).
- Adds comment regarding numerical value used to check if openingHours data is complete. Related to Murray's code review comment [here](https://github.com/Andrew-Chu-MetaU-Engineering/matador/pull/13#discussion_r1669061069).