### PR TITLE
get map bounds on viewport change

### DIFF
--- a/frontend/src/pages/home/Home.jsx
+++ b/frontend/src/pages/home/Home.jsx
@@ -25,6 +25,7 @@ export default function Home({ user }) {
   });
   const [options, setOptions] = useState([]);
   const [route, setRoute] = useState(null);
+  const [mapBounds, setMapBounds] = useState(null);
 
   useEffect(() => {
     if (user != null) fetchProfile(user);
@@ -106,6 +107,7 @@ export default function Home({ user }) {
           <TransitMap
             id="google-map"
             encodedPath={route?.polyline?.encodedPolyline}
+            setMapBounds={setMapBounds}
           />
         </Box>
       </Paper>

--- a/frontend/src/pages/home/TransitMap.jsx
+++ b/frontend/src/pages/home/TransitMap.jsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import { APIProvider, Map } from "@vis.gl/react-google-maps";
 import { Polyline } from "./Polyline";
 
-export default function TransitMap({ encodedPath }) {
+export default function TransitMap({ encodedPath, setMapBounds }) {
   const { VITE_GOOGLE_API_KEY, VITE_DEFAULT_VIEW_LAT, VITE_DEFAULT_VIEW_LNG } =
     import.meta.env;
   return (
@@ -15,6 +15,7 @@ export default function TransitMap({ encodedPath }) {
         defaultZoom={10}
         gestureHandling={"cooperative"}
         disableDefaultUI={true}
+        onBoundsChanged={(e) => setMapBounds(e.detail.bounds)}
       >
         {encodedPath && (
           <Polyline
@@ -30,4 +31,5 @@ export default function TransitMap({ encodedPath }) {
 
 TransitMap.propTypes = {
   encodedPath: PropTypes.string,
+  setMapBounds: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
## Description
Adds the ability to get data about the Google Maps JS display viewport boundaries whenever the viewport changes. This will be fed into the recommendation system in a future PR, once the search filters UI that provides the other input data has been created.

## Reference
[react-google-maps events](https://visgl.github.io/react-google-maps/docs/api-reference/components/map#events)