### PR TITLE
modify locationBias to use rectangle bounds

### DIFF
--- a/backend/FetchResultsUtils.js
+++ b/backend/FetchResultsUtils.js
@@ -81,8 +81,7 @@ async function fetchRouteMatrix(originAddress, destinationAddresses) {
 
 async function fetchPlaces(
   searchQuery,
-  centerLatitude,
-  centerLongitude,
+  locationBiasRect,
   numRequests,
   isFirstRequest,
   nextPageToken = null
@@ -106,12 +105,8 @@ async function fetchPlaces(
   const requestBody = {
     textQuery: searchQuery,
     locationBias: {
-      circle: {
-        center: {
-          latitude: centerLatitude,
-          longitude: centerLongitude,
-        },
-        radius: NEARBY_SEARCH_RADIUS_METERS,
+      rectangle: {
+        ...locationBiasRect
       },
     },
     pageSize: numRequests,
@@ -140,16 +135,14 @@ async function fetchPlaces(
 async function getOptions(
   searchQuery,
   originAddress,
-  centerLatitude,
-  centerLongitude,
+  locationBias,
   numRequests,
   isFirstRequest,
   nextPageToken = null
 ) {
   const { places, nextPageToken: newNextPageToken } = await fetchPlaces(
     searchQuery,
-    centerLatitude,
-    centerLongitude,
+    locationBias,
     numRequests,
     isFirstRequest,
     nextPageToken

--- a/backend/Recommend.js
+++ b/backend/Recommend.js
@@ -94,8 +94,7 @@ async function recommend(query, interests, settings) {
     await fetchUtils.getOptions(
       query,
       settings.originAddress,
-      settings.center.latitude,
-      settings.center.longitude,
+      settings.locationBias,
       NUM_RECOMMENDATIONS,
       true
     );

--- a/backend/RecommendUtils.js
+++ b/backend/RecommendUtils.js
@@ -102,8 +102,7 @@ async function refetch(
       await fetchUtils.getOptions(
         query,
         settings.originAddress,
-        settings.center.latitude,
-        settings.center.longitude,
+        settings.locationBias,
         numRecommendations - options.length,
         false,
         nextPageToken

--- a/backend/routes/googleAPI.js
+++ b/backend/routes/googleAPI.js
@@ -31,17 +31,4 @@ router.get("/computeRouteMatrix", async (req, res) => {
   }
 });
 
-router.get("/nearbyPlaces", async (req, res) => {
-  try {
-    const data = await utils.fetchPlaces(
-      req.query.searchQuery,
-      req.query.centerLatitude,
-      req.query.centerLongitude
-    );
-    res.status(200).send(data);
-  } catch (error) {
-    res.status(500);
-  }
-});
-
 module.exports = router;

--- a/frontend/src/pages/home/Home.jsx
+++ b/frontend/src/pages/home/Home.jsx
@@ -72,9 +72,13 @@ export default function Home({ userId }) {
       isAccessible,
     } = values;
 
+    const { north, south, east, west } = mapBounds;
     const settings = {
       originAddress: originAddress,
-      center: {},
+      locationBias: {
+        low: { latitude: south, longitude: west },
+        high: { latitude: north, longitude: east },
+      },
       departureTime: isCurrentDepartureTime
         ? new Date(Date.now()).toISOString()
         : dayjs(departureTime).toISOString(),


### PR DESCRIPTION
## Description
Changes the locationBias used to find nearby places of interest, from a circle (center and radius) to a rectangle defined by the map's viewport. This allows the user to get recommendations that are near the area of the map they are looking at when they search.

## Notes
This change took longer than expected to implement due to a quirk of the Google Places API, which requires a "low" and "high" coordinate that defines the box used to search nearby. I originally passed in a low of the southeast corner and a high of the northwest corner, but I was getting no results from the API. After debugging, I found that low.longitude must be less than high.longitude. I read in the [documentation](https://developers.google.com/maps/documentation/places/web-service/reference/rest/v1/places#Viewport) that the viewport must be "two diagonally opposite low and high points", but there was only a vague mention of the restriction that I found ("If low.longitude > high.longitude, the longitude range is inverted").