### PR TITLE
route interactivity

### DIFF
--- a/backend/FetchResultsUtils.js
+++ b/backend/FetchResultsUtils.js
@@ -11,10 +11,8 @@ async function fetchRoute(originAddress, destinationAddress) {
   // computes route from origin to destination and their related transit fares and durations
   try {
     const FIELDS = [
-      "routes.duration",
       "routes.polyline",
-      "routes.travel_advisory.transitFare",
-      "routes.legs.stepsOverview",
+      "routes.legs",
       "routes.viewport",
     ];
 

--- a/backend/Recommend.js
+++ b/backend/Recommend.js
@@ -110,6 +110,8 @@ async function recommend(query, interests, settings) {
     query
   );
 
+  await recommendUtils.fetchRoutePolylines(options, settings.originAddress);
+
   // TODO generate interest, preference, and transit vector for each option in one iteration
   const interestScores = await calculateInterestScores(
     query,

--- a/backend/Recommend.js
+++ b/backend/Recommend.js
@@ -110,7 +110,7 @@ async function recommend(query, interests, settings) {
     query
   );
 
-  await recommendUtils.fetchRoutePolylines(options, settings.originAddress);
+  await recommendUtils.fetchRouteDetails(options, settings.originAddress);
 
   // TODO generate interest, preference, and transit vector for each option in one iteration
   const interestScores = await calculateInterestScores(

--- a/backend/RecommendUtils.js
+++ b/backend/RecommendUtils.js
@@ -120,6 +120,14 @@ async function refetch(
   }
 }
 
+async function fetchRoutePolylines(options, originAddress) {
+  let routePromises = options.map((option) =>
+    fetchUtils.fetchRoute(originAddress, option.place.formattedAddress)
+  );
+  const routes = await Promise.all(routePromises);
+  options.forEach((option, i) => (option.route = routes[i].routes[0]));
+}
+
 async function getAlignedInterests(queryEmbedding, interests, getEmbedding) {
   const NEAR_INTEREST_THRESHOLD = 0.1;
   let nearInterests = [];
@@ -155,6 +163,7 @@ module.exports = {
   cosineSimilarity,
   feasibilityFilter,
   refetch,
+  fetchRoutePolylines,
   getAlignedInterests,
   biasPreference,
   normalizeScores,

--- a/backend/RecommendUtils.js
+++ b/backend/RecommendUtils.js
@@ -120,7 +120,7 @@ async function refetch(
   }
 }
 
-async function fetchRoutePolylines(options, originAddress) {
+async function fetchRouteDetails(options, originAddress) {
   let routePromises = options.map((option) =>
     fetchUtils.fetchRoute(originAddress, option.place.formattedAddress)
   );
@@ -163,7 +163,7 @@ module.exports = {
   cosineSimilarity,
   feasibilityFilter,
   refetch,
-  fetchRoutePolylines,
+  fetchRouteDetails,
   getAlignedInterests,
   biasPreference,
   normalizeScores,

--- a/frontend/src/pages/home/Home.css
+++ b/frontend/src/pages/home/Home.css
@@ -1,10 +1,18 @@
 #search-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   flex: 15%;
   background-color: aliceblue;
 }
 
 #search-panel > * {
-  margin: 1rem;
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+#results-scrollarea {
+  flex-grow: 1;
 }
 
 #map-area {

--- a/frontend/src/pages/home/Home.jsx
+++ b/frontend/src/pages/home/Home.jsx
@@ -15,7 +15,7 @@ export default function Home({ userId }) {
   const { VITE_EXPRESS_API } = import.meta.env;
   const [profile, setProfile] = useState(null);
   const [options, setOptions] = useState([]);
-  const [route, setRoute] = useState(null);
+  const [activeOption, setActiveOption] = useState(null);
   const [mapBounds, setMapBounds] = useState(null);
 
   useEffect(() => {
@@ -127,14 +127,19 @@ export default function Home({ userId }) {
           <ScrollArea id="results-scrollarea">
             {options?.length > 0 &&
               options.map((option) => (
-                <SearchResult key={option.place.id} option={option} />
+                <SearchResult
+                  key={option.place.id}
+                  option={option}
+                  active={activeOption?.id === option.place.id}
+                  setActiveOption={setActiveOption}
+                />
               ))}
           </ScrollArea>
         </section>
         <Box id="map-area">
           <TransitMap
             id="google-map"
-            encodedPath={route?.polyline?.encodedPolyline}
+            encodedPath={activeOption?.route}
             setMapBounds={setMapBounds}
           />
         </Box>

--- a/frontend/src/pages/home/Home.jsx
+++ b/frontend/src/pages/home/Home.jsx
@@ -56,6 +56,9 @@ export default function Home({ userId }) {
   }
 
   async function handleSearch(values) {
+    setOptions(null);
+    setActiveOption(null);
+
     const {
       query,
       originAddress,

--- a/frontend/src/pages/home/Home.jsx
+++ b/frontend/src/pages/home/Home.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import PropTypes from "prop-types";
-import { Paper, Box } from "@mantine/core";
+import { Paper, Box, ScrollArea } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import dayjs from "dayjs";
 
@@ -124,12 +124,12 @@ export default function Home({ userId }) {
       <Paper id="home-body">
         <section id="search-panel">
           <Search form={form} handleSearch={handleSearch} />
-          <Box>
+          <ScrollArea id="results-scrollarea">
             {options?.length > 0 &&
               options.map((option) => (
                 <SearchResult key={option.place.id} option={option} />
               ))}
-          </Box>
+          </ScrollArea>
         </section>
         <Box id="map-area">
           <TransitMap

--- a/frontend/src/pages/home/Search.css
+++ b/frontend/src/pages/home/Search.css
@@ -1,4 +1,5 @@
 #search-pane {
+  margin: 1rem;
   padding: 1rem;
   min-width: 21rem;
 }

--- a/frontend/src/pages/home/SearchResult.css
+++ b/frontend/src/pages/home/SearchResult.css
@@ -1,5 +1,4 @@
-
-#place-properties{
+#place-properties {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -10,4 +9,8 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+}
+
+#result-flag-icon {
+  color: red;
 }

--- a/frontend/src/pages/home/SearchResult.css
+++ b/frontend/src/pages/home/SearchResult.css
@@ -1,0 +1,13 @@
+
+#place-properties{
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+#price-and-rating-wrapper {
+  align-self: flex-end;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}

--- a/frontend/src/pages/home/SearchResult.jsx
+++ b/frontend/src/pages/home/SearchResult.jsx
@@ -1,13 +1,36 @@
 import PropTypes from "prop-types";
-import { Card, Text } from "@mantine/core";
+import { Card, Text, Rating, Group } from "@mantine/core";
+import "./SearchResult.css";
 
 export default function SearchResult({ option }) {
+  const { place, extracted } = option;
+  const durationMinutes = Math.round(extracted.duration / 60); // extracted.duration is in seconds
   return (
     <Card shadow="xs" padding="md" radius="md" mb="xs">
-      <Text size="lg">{option.place.displayName.text}</Text>
-      <Text size="md" c="dimmed" truncate="end">
-        1h 26m &middot; $6.25
-      </Text>
+      <Text size="lg">{place.displayName.text}</Text>
+      <div id="place-properties">
+        <Text size="md" c="dimmed" truncate="end">
+          {durationMinutes >= 60 && (
+            <span>{Math.trunc(durationMinutes / 60)}h </span>
+          )}
+          {durationMinutes % 60}m &middot; ${extracted.fare.toFixed(2)}
+        </Text>
+        <div id="price-and-rating-wrapper">
+          {extracted.priceLevel > 0 && (
+            <Text size="sm" c="dimmed" truncate="end">
+              {"$".repeat(extracted.priceLevel)}
+            </Text>
+          )}
+          {place.rating && (
+            <Group gap="xs">
+              <Rating value={place.rating} fractions={2} size="xs" readOnly />
+              <Text size="sm" c="dimmed" truncate="end">
+                {place.rating.toFixed(1)}
+              </Text>
+            </Group>
+          )}
+        </div>
+      </div>
     </Card>
   );
 }

--- a/frontend/src/pages/home/SearchResult.jsx
+++ b/frontend/src/pages/home/SearchResult.jsx
@@ -1,13 +1,28 @@
 import PropTypes from "prop-types";
 import { Card, Text, Rating, Group } from "@mantine/core";
+import { IconFlagFilled } from "@tabler/icons-react";
 import "./SearchResult.css";
 
-export default function SearchResult({ option }) {
-  const { place, extracted } = option;
+export default function SearchResult({ option, active, setActiveOption }) {
+  const { place, route, extracted } = option;
   const durationMinutes = Math.round(extracted.duration / 60); // extracted.duration is in seconds
   return (
-    <Card shadow="xs" padding="md" radius="md" mb="xs">
-      <Text size="lg">{place.displayName.text}</Text>
+    <Card
+      shadow="xs"
+      padding="md"
+      radius="md"
+      mb="xs"
+      onClick={() =>
+        setActiveOption({
+          id: place.id,
+          route: route?.polyline?.encodedPolyline,
+        })
+      }
+    >
+      <Group justify="space-between">
+        <Text size="lg">{place.displayName.text}</Text>
+        {active && <IconFlagFilled id="result-flag-icon" />}
+      </Group>
       <div id="place-properties">
         <Text size="md" c="dimmed" truncate="end">
           {durationMinutes >= 60 && (
@@ -37,4 +52,6 @@ export default function SearchResult({ option }) {
 
 SearchResult.propTypes = {
   option: PropTypes.object.isRequired,
+  active: PropTypes.bool.isRequired,
+  setActiveOption: PropTypes.func.isRequired,
 };

--- a/frontend/src/pages/home/TransitMap.jsx
+++ b/frontend/src/pages/home/TransitMap.jsx
@@ -20,7 +20,7 @@ export default function TransitMap({ encodedPath, setMapBounds }) {
         {encodedPath && (
           <Polyline
             strokeWeight={8}
-            strokeColor={"#000000"}
+            strokeColor={"#ff0000"}
             encodedPath={encodedPath}
           />
         )}


### PR DESCRIPTION
## Description 
Adds feature for user to be able to see a list of search results and their details in a scrollable area, then click on a search result option and see the route associated with it on the map. This uses the fetchRoute to get details such as the polyline from the list of POI options after they have been filtered for feasibility.

## Views
### Initial view after search
<img width="1728" alt="image" src="https://github.com/Andrew-Chu-MetaU-Engineering/matador/assets/75499520/d610c882-a7d3-4566-a261-2f4f8da7576f">

### First result selected
<img width="1728" alt="image" src="https://github.com/Andrew-Chu-MetaU-Engineering/matador/assets/75499520/bf1d0f12-a3d3-42a1-9d8f-fb54392376ec">

### Another result selected
<img width="1725" alt="image" src="https://github.com/Andrew-Chu-MetaU-Engineering/matador/assets/75499520/8b4edf6d-aca3-4f24-984f-33cc53efbd48">