### PR TITLE
fix error with RouteMatrix response ordering

### DIFF
--- a/backend/FetchResultsUtils.js
+++ b/backend/FetchResultsUtils.js
@@ -43,7 +43,12 @@ async function fetchRouteMatrix(
 ) {
   // computes route from origin to destination and their related transit fares and durations
   try {
-    const FIELDS = ["duration", "travel_advisory.transitFare", "condition"];
+    const FIELDS = [
+      "destinationIndex",
+      "duration",
+      "travel_advisory.transitFare",
+      "condition",
+    ];
 
     const requestBody = {
       origins: {
@@ -72,7 +77,9 @@ async function fetchRouteMatrix(
       },
       body: JSON.stringify(requestBody),
     });
-    return await response.json();
+
+    const routeMatrix = await response.json();
+    return routeMatrix.sort((a, b) => a.destinationIndex - b.destinationIndex);
   } catch (error) {
     console.log(error.message);
   }

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,7 +3,6 @@ const cors = require("cors");
 const recommender = require("./Recommend");
 require("dotenv").config();
 
-const googleApiRoute = require("./routes/googleAPI");
 const { router: userRoute, getUser } = require("./routes/user");
 
 const app = express();
@@ -17,7 +16,6 @@ app.get("/", (req, res, next) => {
   next();
 });
 
-app.use("/google", googleApiRoute);
 app.use("/user", userRoute);
 
 app.get("/recommend", async (req, res) => {


### PR DESCRIPTION
## Description
- I discovered that the Google RouteMatrix API returns its route data in an arbitrary and inconsistent order, instead of ordered by origins or destinations.
- The API returns an destinationIndex field, so this PR uses that field to order the results before returning them in the fetchRouteMatrix function.
- It is not necessary to consider the originIndex field because this application will only query one origin at a time.