### PR TITLE
loading state for search

### DIFF
--- a/frontend/src/pages/home/Home.css
+++ b/frontend/src/pages/home/Home.css
@@ -29,3 +29,8 @@
   display: flex;
   height: 100vh;
 }
+
+#results-loading-wrapper {
+  display: flex;
+  justify-content: center;
+}

--- a/frontend/src/pages/home/Home.jsx
+++ b/frontend/src/pages/home/Home.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import PropTypes from "prop-types";
-import { Paper, Box, ScrollArea } from "@mantine/core";
+import { Paper, Box, ScrollArea, Loader } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import dayjs from "dayjs";
 
@@ -17,6 +17,7 @@ export default function Home({ userId }) {
   const [activeOption, setActiveOption] = useState(null);
   const [mapBounds, setMapBounds] = useState(null);
   const [noResultsFound, setNoResultsFound] = useState(false);
+  const [isResultsLoading, setIsResultsLoading] = useState(false);
   const [isographSettings, setIsographSettings] = useState({
     originAddress: "",
     costType: "",
@@ -44,6 +45,7 @@ export default function Home({ userId }) {
 
   async function fetchRecommendations(query, settings) {
     try {
+      setIsResultsLoading(true);
       let url = new URL("recommend", VITE_EXPRESS_API);
       url.searchParams.append("userId", profile.id);
       url.searchParams.append("searchQuery", query);
@@ -59,6 +61,7 @@ export default function Home({ userId }) {
     } catch (error) {
       console.error("Error fetching recommendations:", error);
     }
+    setIsResultsLoading(false);
   }
 
   async function handleFormSubmit(values, e) {
@@ -163,6 +166,11 @@ export default function Home({ userId }) {
       <Paper id="home-body">
         <section id="search-panel">
           <Search form={form} handleFormSubmit={handleFormSubmit} />
+          {isResultsLoading && (
+            <div id="results-loading-wrapper">
+              <Loader color="blue" size="xl" type="dots" />
+            </div>
+          )}
           <ScrollArea id="results-scrollarea">
             {options?.length > 0 &&
               options.map((option) => (


### PR DESCRIPTION
## Description
- Adds a loading indicator on the search panel after the search button is clicked and before results load
    - I estimate the time between search and load is around 1 or 2 seconds, during which the Places and Routes APIs are queried and the recommendation system filters and organizes the results
 - This is related to the MetaU project requirement for "Your app uses a loading state to create visual polish"
  
## Resources
[Mantine Loader component](https://mantine.dev/core/loader/)
[Loading state in React guide](https://rapidapi.com/guides/loading-state-react)

## Views
<img width="368" alt="image" src="https://github.com/user-attachments/assets/81faa172-a3f3-4c67-9ccc-7f5153bf0d89">
