### PR TITLE
tooltip mvp

### DIFF
--- a/backend/IsographUtils.js
+++ b/backend/IsographUtils.js
@@ -62,13 +62,14 @@ async function fetchCosts(origin, samplePoints, costType, departureTime) {
     );
 
     if (costType === COST_TYPE_DURATION) {
-      parseCostFunction = fetchResultsUtils.parseDuration;
+      return routesData.map(
+        (route) => fetchResultsUtils.parseDuration(route) / 60
+      ); // convert to minutes
     } else if (costType === COST_TYPE_FARE) {
-      parseCostFunction = fetchResultsUtils.calculateFare;
+      return routesData.map((route) => fetchResultsUtils.calculateFare(route));
     } else {
       console.error(COST_TYPE_ERROR_MSG);
     }
-    return routesData.map((route) => parseCostFunction(route));
   } catch (error) {
     console.error(error.message);
   }

--- a/frontend/src/components/Tooltip.css
+++ b/frontend/src/components/Tooltip.css
@@ -1,0 +1,7 @@
+.mouse-tracker {
+  position: fixed;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  background-color: white;
+}

--- a/frontend/src/components/Tooltip.jsx
+++ b/frontend/src/components/Tooltip.jsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import "./Tooltip.css";
+
+export default function Tooltip({ text, mouseOffset }) {
+  const [mousePosition, setMousePosition] = useState({
+    x: null,
+    y: null,
+  });
+
+  useEffect(() => {
+    const updateMousePosition = (e) => {
+      setMousePosition({ x: e.clientX, y: e.clientY });
+    };
+    window.addEventListener("mousemove", updateMousePosition);
+    return () => {
+      window.removeEventListener("mousemove", updateMousePosition);
+    };
+  }, []);
+
+  return (
+    <article
+      className="mouse-tracker"
+      style={{
+        transform: `translate(${mousePosition.x + mouseOffset.x}px, ${
+          mousePosition.y + mouseOffset.y
+        }px)`,
+      }}
+    >
+      <div>{text}</div>
+    </article>
+  );
+}
+
+Tooltip.propTypes = {
+  text: PropTypes.string.isRequired,
+  mouseOffset: PropTypes.object.isRequired,
+};

--- a/frontend/src/pages/home/Isograph.jsx
+++ b/frontend/src/pages/home/Isograph.jsx
@@ -83,12 +83,9 @@ export default function Isograph({ isographSettings }) {
         break;
     }
 
-    let displayCost =
-      i === contours.length - 1
-        ? `> ${prepend}${contours[i].value}${append}`
-        : `< ${prepend}${contours[i + 1].value}${append}`;
-
-    return displayCost;
+    return i === contours.length - 1
+      ? `> ${prepend}${contours[i].value}${append}`
+      : `< ${prepend}${contours[i + 1].value}${append}`;
   }
 
   function addIsographStyling(mapLayer, featureCollection) {

--- a/frontend/src/pages/home/Isograph.jsx
+++ b/frontend/src/pages/home/Isograph.jsx
@@ -72,10 +72,21 @@ export default function Isograph({ isographSettings }) {
   }
 
   function formatDisplayCost(i, contours) {
+    let prepend = "";
+    let append = "";
+    switch (isographSettings.costType) {
+      case VITE_COST_TYPE_DURATION:
+        append = " min";
+        break;
+      case VITE_COST_TYPE_FARE:
+        prepend = "$";
+        break;
+    }
+
     let displayCost =
       i === contours.length - 1
-        ? `>${contours[i].value}`
-        : `<${contours[i + 1].value}`;
+        ? `> ${prepend}${contours[i].value}${append}`
+        : `< ${prepend}${contours[i + 1].value}${append}`;
 
     return displayCost;
   }


### PR DESCRIPTION
## Description
- Adds a tooltip on hover over a region of the isograph contour map, displaying the cost value of either transit duration or fare
- Relates to the cursor interaction requirement of the MetaU project plan
- Further styling will be added to the tooltip in future PRs

## Views

I was not able to capture my cursor in a screenshot, but when the application is in use, the cursor is directly below the tooltip.

<img width="920" alt="image" src="https://github.com/user-attachments/assets/2116f9b9-398b-4042-b0fd-01fce2a00841">
