### PR TITLE
polynomial calculation enhancements

### DIFF
--- a/backend/Isograph.js
+++ b/backend/Isograph.js
@@ -40,6 +40,7 @@ async function isograph(originAddress, costType, departureTime) {
       ])
     )
     .flat();
+  costSamples.push([...originCoordinates, 0]);
 
   const estimations = await isographUtils.fetchPolynomialEstimation(
     costSamples,

--- a/isographsAPI/estimation.py
+++ b/isographsAPI/estimation.py
@@ -41,8 +41,9 @@ def sample_polynomial(dimension_sample_count, lat, lng, powers_lat, powers_lng, 
             estimate_sample_lng.reshape(-1, 1) ** powers_lng)
     estimate_cost = np.dot(estimation_matrix, coefficients).reshape(estimate_sample_lat.shape)
 
-    # reshape into 3 columns of [lng, lat, cost]
-    return np.array([estimate_sample_lng, estimate_sample_lat, estimate_cost]).T.reshape(-1, 3)
+    # clip any negative cost estimates and reshape into 3 columns of [lng, lat, cost]
+    return (np.array([estimate_sample_lng, estimate_sample_lat, np.clip(estimate_cost, 0, None)])
+            .T.reshape(-1, 3))
 
 
 def format_data(data):


### PR DESCRIPTION
## Description
- Makes enhancements to the isograph generation system, particularly in the calculation of the polynomial regression, to improve its accuracy and understandability
    - Adds the origin as a sample point with 0 cost, instead of relying only on the sampled points to run the regression. This was previously not included because I wanted to test the accuracy of the prediction with and without this additionally added point. Through testing various configurations of the isographs, I've found that adding this point yields more accurate results.
    - Clips any negative values on the polynomial regression's sampled points to 0. Since the isogrpah system is based off of a polynomial regression, it may predict areas of negative cost based on the sampled points. However, this does not make sense in real life, so I have chosen to clip these estimate values to 0. Previously, I was simply removing contour areas of negative cost, but now, the entire contour area will be visible.


## Views
### Before (missing areas of contour map)
<img width="356" alt="image" src="https://github.com/user-attachments/assets/b5224f23-346c-40bc-82b6-e83387f76568">


### After
<img width="656" alt="image" src="https://github.com/user-attachments/assets/dd99dc72-6c79-404e-9a66-231051a151ef">
