### PR TITLE
tooltip styling

### DIFF
--- a/frontend/src/components/Tooltip.css
+++ b/frontend/src/components/Tooltip.css
@@ -2,6 +2,22 @@
   position: fixed;
   top: 0;
   left: 0;
+  width: 90px;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
   pointer-events: none;
-  background-color: white;
+  color: white;
+  background-color: red;
+}
+
+.mouse-tracker::after {
+  content: " "; /* add an arrow below tooltip */
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 7px;
+  border-style: solid;
+  border-color: red transparent transparent transparent;
 }

--- a/frontend/src/pages/home/Isograph.jsx
+++ b/frontend/src/pages/home/Isograph.jsx
@@ -176,7 +176,7 @@ export default function Isograph({ isographSettings }) {
 
   return (
     tooltipValue && (
-      <Tooltip text={tooltipValue} mouseOffset={{ x: -15, y: -30 }} />
+      <Tooltip text={tooltipValue} mouseOffset={{ x: -47, y: -41 }} />
     )
   );
 }


### PR DESCRIPTION
## Description
- Adds additional styling to the tooltip, related to the cursor interaction requirement of the project.

## Reference
[::after](https://developer.mozilla.org/en-US/docs/Web/CSS/::after)
## Views
### Before
<img width="536" alt="image" src="https://github.com/user-attachments/assets/480f751e-f449-4d8d-a660-26c2eb5571c0">

### After
<img width="622" alt="image" src="https://github.com/user-attachments/assets/e2401c38-0324-4a61-a002-eff3ea4f22b5">
