### PR TITLE
dynamic weight adjustment (stretch)

### DIFF
--- a/backend/WeightLearning.js
+++ b/backend/WeightLearning.js
@@ -14,13 +14,12 @@ function calculateNewWeights(
 ) {
   if (likedOptionIndex >= optionScores.length) return currentWeights;
 
-  // TODO handle isUnlike condition completely
-
-  const likeError = calculateError(optionScores, likedOptionIndex, isUnlike);
+  let likeError = calculateError(optionScores, likedOptionIndex, isUnlike);
+  if (isUnlike) likeError = likeError.map((val) => -val);
   return calculateAdjustedWeights(likeError, currentWeights);
 }
 
-function calculateError(optionScores, likedOptionIndex, isUnlike) {
+function calculateError(optionScores, likedOptionIndex) {
   const error = [0, 0, 0];
   const likedOption = optionScores[likedOptionIndex];
   optionScores.forEach((option, rank) => {
@@ -28,9 +27,8 @@ function calculateError(optionScores, likedOptionIndex, isUnlike) {
       const likedScoreDiff = likedOption[scoreTypeIdx] - score;
       // focus on items that are out of the expected order
       if (
-        isUnlike !== // "out-of-order" condition inverts when isUnlike
-        ((likedScoreDiff > 0 && likedOptionIndex > rank) ||
-          (likedScoreDiff < 0 && likedOptionIndex < rank))
+        (likedScoreDiff > 0 && likedOptionIndex > rank) ||
+        (likedScoreDiff < 0 && likedOptionIndex < rank)
       ) {
         // squared error of score, weighted by difference in rank
         error[scoreTypeIdx] += (likedOptionIndex - rank) * likedScoreDiff ** 2;

--- a/frontend/src/pages/home/Home.jsx
+++ b/frontend/src/pages/home/Home.jsx
@@ -162,6 +162,32 @@ export default function Home({ userId }) {
     },
   });
 
+  async function handleLikePlace(placeId, isUnlike) {
+    try {
+      const response = await fetch(
+        new URL(`user/${userId}/likeAndUpdateWeights`, VITE_EXPRESS_API),
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            placeId: placeId,
+            options: options,
+            isUnlike: isUnlike,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`HTTP error. Status ${response.status}`);
+      }
+      await fetchProfile(userId);
+    } catch (error) {
+      console.error("Error updating likes and weights:", error);
+    }
+  }
+
   return (
     <>
       <Paper id="home-body">
@@ -181,6 +207,8 @@ export default function Home({ userId }) {
               activeOption={activeOption}
               setActiveOption={setActiveOption}
               setIsRouteDetailDisplayed={setIsRouteDetailDisplayed}
+              likedPlaces={profile?.likedPlaces}
+              handleLikePlace={handleLikePlace}
             />
           )}
         </section>

--- a/frontend/src/pages/home/search/SearchPane.jsx
+++ b/frontend/src/pages/home/search/SearchPane.jsx
@@ -13,6 +13,8 @@ export default function SearchPane({
   activeOption,
   setActiveOption,
   setIsRouteDetailDisplayed,
+  likedPlaces,
+  handleLikePlace,
 }) {
   return (
     <>
@@ -31,6 +33,10 @@ export default function SearchPane({
               activeOption={activeOption}
               setActiveOption={setActiveOption}
               setIsRouteDetailDisplayed={setIsRouteDetailDisplayed}
+              liked={likedPlaces
+                ?.map((place) => place.id)
+                .includes(option.place.id)}
+              handleLikePlace={handleLikePlace}
             />
           ))}
         {noResultsFound && (
@@ -50,4 +56,6 @@ SearchPane.propTypes = {
   activeOption: PropTypes.object,
   setActiveOption: PropTypes.func.isRequired,
   setIsRouteDetailDisplayed: PropTypes.func.isRequired,
+  likedPlaces: PropTypes.array,
+  handleLikePlace: PropTypes.func.isRequired,
 };

--- a/frontend/src/pages/home/search/SearchResult.jsx
+++ b/frontend/src/pages/home/search/SearchResult.jsx
@@ -1,6 +1,10 @@
 import PropTypes from "prop-types";
-import { Card, Text, Rating, Group, Button } from "@mantine/core";
-import { IconFlagFilled } from "@tabler/icons-react";
+import { Card, Text, Rating, Group, Button, ActionIcon } from "@mantine/core";
+import {
+  IconHeart,
+  IconHeartFilled,
+  IconFlagFilled,
+} from "@tabler/icons-react";
 import "./SearchResult.css";
 
 export default function SearchResult({
@@ -8,8 +12,13 @@ export default function SearchResult({
   activeOption,
   setActiveOption,
   setIsRouteDetailDisplayed,
+  liked,
+  handleLikePlace,
 }) {
-  const { place, extracted } = option;
+  const {
+    place: { id, displayName, rating },
+    extracted,
+  } = option;
   const durationMinutes = Math.round(extracted.duration / 60); // extracted.duration is in seconds
 
   return (
@@ -19,17 +28,28 @@ export default function SearchResult({
       radius="md"
       mb="xs"
       onClick={() => {
-        if (activeOption?.place.id !== option?.place.id) {
+        if (activeOption?.place.id !== id) {
           setActiveOption(option);
           setIsRouteDetailDisplayed(false);
         }
       }}
     >
       <Group justify="space-between">
-        <Text size="lg">{place.displayName.text}</Text>
-        {activeOption?.place.id === option?.place.id && (
-          <IconFlagFilled id="result-flag-icon" />
-        )}
+        <Text size="lg">{displayName.text}</Text>
+        <Group>
+          {activeOption?.place.id === option?.place.id && (
+            <IconFlagFilled id="result-flag-icon" />
+          )}
+          <ActionIcon
+            onClick={() =>
+              liked ? handleLikePlace(id, true) : handleLikePlace(id, false)
+            }
+            color="red"
+            variant="light"
+          >
+            {liked ? <IconHeartFilled /> : <IconHeart />}
+          </ActionIcon>
+        </Group>
       </Group>
       <div id="place-properties">
         <Text size="md" c="dimmed" truncate="end">
@@ -44,11 +64,11 @@ export default function SearchResult({
               {"$".repeat(extracted.priceLevel)}
             </Text>
           )}
-          {place.rating && (
+          {rating && (
             <Group gap="xs">
-              <Rating value={place.rating} fractions={2} size="xs" readOnly />
+              <Rating value={rating} fractions={2} size="xs" readOnly />
               <Text size="sm" c="dimmed" truncate="end">
-                {place.rating.toFixed(1)}
+                {rating.toFixed(1)}
               </Text>
             </Group>
           )}
@@ -74,4 +94,6 @@ SearchResult.propTypes = {
   activeOption: PropTypes.object,
   setActiveOption: PropTypes.func.isRequired,
   setIsRouteDetailDisplayed: PropTypes.func.isRequired,
+  liked: PropTypes.bool.isRequired,
+  handleLikePlace: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
## Description
- Develops weight learning algorithm further to make sure that any positive adjustments are balanced by negative adjustments
- Supports unliking an item, and handles logic so that the weights return to the values before liking that item (i.e liking then unliking lead to net zero change in weights)
- Adds frontend event handling / fetching logic for the user's liked places

## Documentation
- [Stretch goal documentation](https://docs.google.com/document/d/196W2taGPrz_UocbDkarn6ZfklINS19WNNgjkFcew4Os/edit)

## Resources
- [Many-to-many relation deletion logic, Prisma documentation (for likedPlace)](https://www.prisma.io/docs/orm/prisma-client/queries/relation-queries#disconnect-a-related-record)

## Test Plan / Views
![demow](https://github.com/user-attachments/assets/62c50d9d-1672-4e8b-8453-6c7feba8a775)
