### PR TITLE
community recommendations boost (stretch)

### DIFF
--- a/backend/RecommendCommunity.js
+++ b/backend/RecommendCommunity.js
@@ -113,11 +113,11 @@ function calculatePlaceScore(likeUsers, otherUsersSimilarityMap) {
   if (likeUsers.length === 0) return null;
 
   const userScores = likeUsers.map((user) =>
-    otherUsersSimilarityMap.get(user.id)
+    otherUsersSimilarityMap.get(user.id) + 1 // each user like should be >= 1
   );
 
-  // boost factor should be >= 1, but use sqrt to reduce large values
-  return Math.sqrt(userScores.reduce((sum, val) => sum + val)) + 1;
+  // use sqrt to reduce large values, with sqrt(x+1) to set y-intercept at 1
+  return Math.sqrt(userScores.reduce((sum, val) => sum + val) + 1);
 }
 
 module.exports = {

--- a/backend/RecommendCommunity.js
+++ b/backend/RecommendCommunity.js
@@ -1,0 +1,123 @@
+const recommendUtils = require("./RecommendUtils");
+const { getPlaceLikes } = require("./routes/place");
+
+async function fetchCommunityLikes(placeIds) {
+  const likePlaceDataPromises = placeIds.map((placeId) =>
+    getPlaceLikes(placeId)
+  );
+  const likedPlaceData = await Promise.all(likePlaceDataPromises);
+  return Object.fromEntries(
+    placeIds.map((placeId, i) => [placeId, likedPlaceData[i]])
+  );
+}
+
+async function scoreLikedPlaces(primaryUser, likedPlaceData) {
+  // set up for userInterestSimilarity
+  const transformer = await recommendUtils.getTransformer();
+  const getEmbedding = recommendUtils.getEmbedder(transformer);
+  const primaryUserInterestEmbedding = await getEmbedding(
+    primaryUser.interests.join()
+  );
+
+  // add users to a set to prevent duplicate comparisons, but convert back to array for use in Promise.all
+  const otherUsers = Array.from(
+    new Set(
+      Object.values(likedPlaceData)
+        .map((placeData) => (placeData == null ? [] : placeData.users))
+        .flat()
+        .filter((user) => user.id !== primaryUser.id)
+    )
+  );
+
+  const otherUsersSimilarity = await Promise.all(
+    otherUsers.map((otherUser) =>
+      userSimilarity(
+        otherUser,
+        primaryUserInterestEmbedding,
+        primaryUser.likedPlaces,
+        getEmbedding
+      )
+    )
+  );
+  const otherUsersSimilarityMap = new Map(
+    otherUsers.map((user, i) => [user.id, otherUsersSimilarity[i]])
+  );
+
+  const scores = {};
+  for (const [placeId, place] of Object.entries(likedPlaceData)) {
+    scores[placeId] =
+      place?.users != null
+        ? calculatePlaceScore(
+            place.users.filter((user) => user.id !== primaryUser.id), // disregard own like in community rankings
+            otherUsersSimilarityMap
+          )
+        : null;
+  }
+  return scores;
+}
+
+async function userSimilarity(
+  otherUser,
+  primaryUserInterestEmbedding,
+  primaryUserLikedPlaces,
+  getEmbedding
+) {
+  const interestSimilarity = await userInterestSimilarity(
+    otherUser.interests,
+    primaryUserInterestEmbedding,
+    getEmbedding
+  );
+
+  const likeSimilarity = userLikeSimilarity(
+    primaryUserLikedPlaces.map((place) => place.id),
+    otherUser.likedPlaces.map((place) => place.id)
+  );
+
+  const similarityScores = [interestSimilarity, likeSimilarity];
+  return (
+    similarityScores.reduce((sum, val) => sum + val) / similarityScores.length +
+    1 // any like should contribute at least a value of 1
+  );
+}
+
+async function userInterestSimilarity(
+  otherUserInterests,
+  primaryUserInterestEmbedding,
+  getEmbedding
+) {
+  if (otherUserInterests.length === 0) {
+    return 0;
+  }
+
+  return recommendUtils.cosineSimilarity(
+    await getEmbedding(otherUserInterests.join()),
+    primaryUserInterestEmbedding
+  );
+}
+
+function userLikeSimilarity(primaryUserLikes, otherUserLikes) {
+  if (primaryUserLikes.length === 0 || otherUserLikes.length === 0) {
+    return 0;
+  }
+
+  // compare proportions of interests in common
+  return (
+    // take size of intersection over size of union
+    primaryUserLikes.filter((likedPlace) => otherUserLikes.includes(likedPlace))
+      .length / new Set([...primaryUserLikes, ...otherUserLikes]).size
+  );
+}
+
+function calculatePlaceScore(likeUsers, otherUsersSimilarityMap) {
+  if (likeUsers.length === 0) return null;
+
+  const userScores = likeUsers.map((user) =>
+    otherUsersSimilarityMap.get(user.id)
+  );
+  return userScores.reduce((sum, val) => sum + val) / userScores.length;
+}
+
+module.exports = {
+  fetchCommunityLikes,
+  scoreLikedPlaces,
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -27,13 +27,8 @@ app.get("/recommend", async (req, res) => {
     const profile = await getUser(userId);
     const options = await recommender.recommend(
       searchQuery,
-      profile.interests,
+      profile,
       JSON.parse(settings),
-      {
-        interest: profile.weightInterest,
-        preference: profile.weightPreference,
-        transit: profile.weightTransit,
-      }
     );
     res.status(200).send(options);
   } catch (error) {

--- a/backend/routes/place.js
+++ b/backend/routes/place.js
@@ -9,18 +9,22 @@ router.get("/", async (req, res) => {
   res.status(200).json(places);
 });
 
-router.get("/:id/", async (req, res) => {
-  const numLikes = await prisma.likedPlace.findUnique({
+async function getPlaceLikes(placeId) {
+  const likedPlaces = await prisma.likedPlace.findUnique({
     where: {
-      id: req.params.id,
+      id: placeId,
     },
     select: {
-      _count: {
-        select: { users: true },
+      users: {
+        select: {
+          id: true,
+          interests: true,
+          likedPlaces: true,
+        },
       },
     },
   });
-  res.status(200).json(numLikes);
-});
+  return likedPlaces;
+}
 
-module.exports = { router };
+module.exports = { router, getPlaceLikes };

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -16,6 +16,7 @@ async function getUser(id) {
   // for use internally within backend
   const user = await prisma.user.findUnique({
     where: { id: id },
+    include: { likedPlaces: true },
   });
   return user;
 }


### PR DESCRIPTION
## Description
- Adds the "likes" of other users on the platform as a factor in ranking and recommending places of interests.
- This algorithm rewards both the quantity of likes as well as the "quality" of likes, based on how similar the other user who awarded that like is to the current user.
   - The similarity of users is computed from their profile interests and place "like" data

## Documentation
The planning and design of this system is detailed in the document below.
[Stretch Feature Planning](https://docs.google.com/document/d/196W2taGPrz_UocbDkarn6ZfklINS19WNNgjkFcew4Os/edit)

## Test Plan
An example of a test I've run is the following:

User A profile:
After searching, user A received the following places in their results, with corresponding null community boosts because no other user had liked any of the places.
 ```
 'ChIJlQ6x1DFnhYARhfeL7CRln5Y' => null,
  'ChIJW-4ApCd_j4AR7woQDYORh5o' => null,
  'ChIJx9l-zOMzjoARX782QnRxoO8' => null
```

User B profile:
After searching, user B received the following places in their results, with corresponding the community boosts.
```
  'ChIJlQ6x1DFnhYARhfeL7CRln5Y' => 1.7376438786702986,
  'ChIJW-4ApCd_j4AR7woQDYORh5o' => 1.7376438786702986,
  'ChIJx9l-zOMzjoARX782QnRxoO8' => null
```
These boosts were caused by the fact that user B's profile had a liked place and interest in common with user A.
User B's interest similarity score was 1.7376438786702986 and like similarity score was 0.5, with user A.