### PR TITLE
optimize isograph fetching (stretch)

### DIFF
--- a/backend/FetchResultsUtils.js
+++ b/backend/FetchResultsUtils.js
@@ -271,10 +271,12 @@ function parseAccessibility(place) {
 }
 
 function parseDuration(route) {
+  if (route?.duration == null) return null;
   return parseInt(route.duration, 10);
 }
 
 function calculateFare(route) {
+  if (route?.travelAdvisory?.transitFare == null) return null;
   const { units = 0, nanos = 0 } = route.travelAdvisory.transitFare;
   return parseInt(units) + nanos * 10 ** -9;
 }

--- a/backend/Isograph.js
+++ b/backend/Isograph.js
@@ -5,6 +5,8 @@ const {
   STEP_SIZE, // increments to sample, in meters
   POLYNOMIAL_ORDER,
   POLYNOMIAL_DIMENSIONAL_SAMPLE_COUNT, // number of samples to take along each side of lat/lng grid
+  COST_TYPE_DURATION,
+  COST_TYPE_FARE,
 } = process.env;
 const SAMPLING_DISTANCES = Array.from(
   { length: SAMPLES_PER_DIRECTION },
@@ -13,11 +15,11 @@ const SAMPLING_DISTANCES = Array.from(
 
 /**
  * Samples the cost (fare or duration) to get to coordinates around the origin address,
- *  then fetches points from polynomial regression model fitted to the cost 
+ *  then fetches points from polynomial regression model fitted to the cost
  *  samples from a FastAPI server.
  * Any points in the polynomial regression model that are negative are clipped to 0.
  */
-async function isograph(originAddress, costType, departureTime) {
+async function isograph(originAddress, departureTime) {
   const originCoordinates = await isographUtils.geocode(originAddress);
 
   // Each element of sampleInfo holds sample points for a single radial direction
@@ -36,25 +38,25 @@ async function isograph(originAddress, costType, departureTime) {
   await isographUtils.insertSampleCosts(
     sampleInfo,
     originCoordinates,
-    costType,
     departureTime
   );
-  const costSamples = sampleInfo
-    .map((directionalSamples) =>
-      directionalSamples.coordinates.map((coordinate, i) => [
-        ...coordinate,
-        directionalSamples.costs[i],
-      ])
-    )
-    .flat();
-  costSamples.push([...originCoordinates, 0]); // add the origin as a sample of cost 0
 
-  const estimations = await isographUtils.fetchPolynomialEstimation(
-    costSamples,
-    POLYNOMIAL_ORDER,
-    POLYNOMIAL_DIMENSIONAL_SAMPLE_COUNT
-  );
-  return estimations.estimates;
+  const polynomialEstimates = {};
+  for (const costType of [COST_TYPE_DURATION, COST_TYPE_FARE]) {
+    const costPoints = isographUtils.extractCostPoints(
+      sampleInfo,
+      originCoordinates,
+      costType
+    );
+
+    const estimations = await isographUtils.fetchPolynomialEstimation(
+      costPoints,
+      POLYNOMIAL_ORDER,
+      POLYNOMIAL_DIMENSIONAL_SAMPLE_COUNT
+    );
+    polynomialEstimates[costType] = estimations.estimates;
+  }
+  return polynomialEstimates;
 }
 
 module.exports = { isograph };

--- a/backend/index.js
+++ b/backend/index.js
@@ -28,7 +28,7 @@ app.get("/recommend", async (req, res) => {
     const options = await recommender.recommend(
       searchQuery,
       profile,
-      JSON.parse(settings),
+      JSON.parse(settings)
     );
     res.status(200).send(options);
   } catch (error) {
@@ -38,12 +38,8 @@ app.get("/recommend", async (req, res) => {
 
 app.get("/isograph", async (req, res) => {
   try {
-    const { originAddress, costType, departureTime } = req.query;
-    const isographData = await isograph.isograph(
-      originAddress,
-      costType,
-      departureTime
-    );
+    const { originAddress, departureTime } = req.query;
+    const isographData = await isograph.isograph(originAddress, departureTime);
     res.status(200).send(isographData);
   } catch (error) {
     res.status(500);

--- a/frontend/src/pages/home/Isograph.jsx
+++ b/frontend/src/pages/home/Isograph.jsx
@@ -7,7 +7,7 @@ const { VITE_EXPRESS_API, VITE_COST_TYPE_DURATION, VITE_COST_TYPE_FARE } =
   import.meta.env;
 
 export default function Isograph({ isographSettings }) {
-  const REFETCH_THRESHOLD_MS = 60 * 60 * 1000; // only fetch new data for >1min diff in departure time
+  const REFETCH_THRESHOLD_MS = 60 * 1000; // only fetch new data for >1min diff in departure time
   const [isographData, setIsographData] = useState(null);
   const [isographMapLayer, setIsographMapLayer] = useState(null);
   const [tooltipValue, setTooltipValue] = useState(null);

--- a/frontend/src/pages/home/Isograph.jsx
+++ b/frontend/src/pages/home/Isograph.jsx
@@ -30,10 +30,6 @@ export default function Isograph({ isographSettings }) {
           new Date(prevIsographSettings.departureTime)
       ) < REFETCH_THRESHOLD_MS
     ) {
-      setPrevIsographSettings((prev) => ({
-        ...prev,
-        originAddress: isographSettings.originAddress,
-      }));
       return;
     } else {
       setPrevIsographSettings(isographSettings);


### PR DESCRIPTION
## Description
- Optimizes the fetching logic for isographs. Previously, only one isograph type was fetched and displayed at a time. Now, both cost and fare data is fetched in one call and both polynomials are calculated and returned in one call.
- After both isograph data are fetched, changing the toggle on the frontend only changes the displayed isograph without a new fetch
- A new fetch only occurs if the originAddress changes or the departureTime changes more than 1 minute from the previous departureTime

## Notes
This change turned out to be much more challenging than I had anticipated. I was able to complete the backend changes fairly quickly, but during the testing process, I discovered that the isograph kept refetching when I only changed the costType.
I thought this was a problem with rendering / props being sent from the parent Home component. I got sidetracked on a dead end, where I thought I had to use memo or shouldComponentUpdate. However, I eventually found that the issue was in my use of current time for the departureTime, which meant that the change in current time was causing rerenders.

I solved this issue by adding logic that checks whether departureTime has changed more than 1 minute, before refetching.

## Resources
https://react.dev/reference/react/memo#specifying-a-custom-comparison-function 
https://stackoverflow.com/questions/7763327/how-to-calculate-date-difference-in-javascript 