### PR TITLE
accordion route details

### DIFF
--- a/frontend/src/pages/home/routedetail/RouteDetail.css
+++ b/frontend/src/pages/home/routedetail/RouteDetail.css
@@ -5,16 +5,3 @@
   flex: 15%;
   background-color: aliceblue;
 }
-
-.fade-animation-wrapper {
-  opacity: 0;
-}
-
-@keyframes fade-in {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}

--- a/frontend/src/pages/home/routedetail/RouteDetail.jsx
+++ b/frontend/src/pages/home/routedetail/RouteDetail.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import { Button, Paper, ScrollArea, Text } from "@mantine/core";
 import { IconArrowBack } from "@tabler/icons-react";
-import StepInfoPane from "./StepInfoPane";
+import StepsOverview from "./StepsOverview";
 import "./RouteDetail.css";
 
 export default function RouteDetail({ option, setIsRouteDetailDisplayed }) {
@@ -10,11 +10,8 @@ export default function RouteDetail({ option, setIsRouteDetailDisplayed }) {
     route: { legs },
   } = option;
 
-  function fadeIn(i) {
-    const DURATION = 800; // values found through visual testing
-    const DELAY = 100;
-    return `fade-in ${DURATION}ms ease-in ${DELAY * i}ms forwards`;
-  }
+  // A RouteLeg object; only one leg because no other intermediate waypoints specified
+  const { localizedValues, steps, stepsOverview } = legs[0];
 
   return (
     <Paper id="detail-panel">
@@ -29,21 +26,15 @@ export default function RouteDetail({ option, setIsRouteDetailDisplayed }) {
           Back
         </Button>
       </section>
-      <Text size="lg" fw={800} ta="center" m="sm">
+      <Text size="lg" fw={800} ta="center">
         Route to {place.displayName.text}
       </Text>
+      <Text size="sm" ta="center" mb="xs">
+        Trip Details: {localizedValues.distance.text} |{" "}
+        {localizedValues.duration.text}
+      </Text>
       <ScrollArea scrollbars="y">
-        {legs.map((leg) => {
-          return leg.steps?.map((step, i) => (
-            <article
-              className="fade-animation-wrapper"
-              key={i}
-              style={{ animation: fadeIn(i) }}
-            >
-              <StepInfoPane step={step} />
-            </article>
-          ));
-        })}
+        <StepsOverview stepsOverview={stepsOverview} steps={steps} />
       </ScrollArea>
     </Paper>
   );

--- a/frontend/src/pages/home/routedetail/StepInfoPane.css
+++ b/frontend/src/pages/home/routedetail/StepInfoPane.css
@@ -1,12 +1,11 @@
 .detail-pane {
   margin: 0 0rem 0.5rem 0rem;
   padding: 1rem;
-  min-width: 21rem;
-  border-radius: 20px;
+  transition: padding 0.3s ease-in-out 0.3s;
 }
 
 .detail-pane:hover {
-  transition: padding 0.5s ease-in-out 0.5s;
+  transition: padding 0.2s ease-in-out 0.2s;
   padding: 2rem 1rem;
 }
 

--- a/frontend/src/pages/home/routedetail/StepsOverview.css
+++ b/frontend/src/pages/home/routedetail/StepsOverview.css
@@ -1,0 +1,16 @@
+.accordion-item {
+  min-width: 21rem;
+}
+
+.fade-animation{
+  opacity: 0;
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}

--- a/frontend/src/pages/home/routedetail/StepsOverview.jsx
+++ b/frontend/src/pages/home/routedetail/StepsOverview.jsx
@@ -1,0 +1,66 @@
+import PropTypes from "prop-types";
+import { Accordion } from "@mantine/core";
+import { IconWalk, IconTrain } from "@tabler/icons-react";
+import StepInfoPane from "./StepInfoPane";
+import "./StepsOverview.css";
+
+function StepsOverview({ stepsOverview, steps }) {
+  const TRAVEL_MODE_ICONS = {
+    TRANSIT: <IconTrain />,
+    WALK: <IconWalk />,
+  };
+
+  const overviewAccordionItems = stepsOverview.multiModalSegments.map(
+    (overview, i) => {
+      const {
+        navigationInstruction,
+        stepStartIndex,
+        stepEndIndex,
+        travelMode,
+      } = overview;
+
+      const overviewTitle =
+        navigationInstruction == null
+          ? travelMode.charAt(0, 0) + travelMode.slice(1).toLowerCase()
+          : navigationInstruction.instructions;
+
+      return (
+        <Accordion.Item
+          key={i}
+          value={overviewTitle}
+          className="accordion-item fade-animation"
+          style={{ animation: fadeIn(i) }}
+          mt="xs"
+        >
+          <Accordion.Control icon={TRAVEL_MODE_ICONS[travelMode]}>
+            {overviewTitle}
+          </Accordion.Control>
+          <Accordion.Panel>
+            {steps.slice(stepStartIndex, stepEndIndex + 1).map((step, j) => (
+              <StepInfoPane key={j} step={step} />
+            ))}
+          </Accordion.Panel>
+        </Accordion.Item>
+      );
+    }
+  );
+
+  function fadeIn(i) {
+    const DURATION = 1000; // values found through visual testing
+    const DELAY = 500;
+    return `fade-in ${DURATION}ms ease-in ${DELAY * i}ms forwards`;
+  }
+
+  return (
+    <Accordion transitionDuration={1000} variant="separated" radius="md">
+      {overviewAccordionItems}
+    </Accordion>
+  );
+}
+
+StepsOverview.propTypes = {
+  stepsOverview: PropTypes.object.isRequired,
+  steps: PropTypes.array.isRequired,
+};
+
+export default StepsOverview;


### PR DESCRIPTION
## Description
- Adds a steps overview to the route details view, so that the route steps are now organized under headings, instead of them being all at the same hierarchy
- The fade in animation has been transferred to the steps overview level
- Adds trip details like total duration and distance

## Resources
https://developers.google.com/maps/documentation/routes/reference/rest/v2/TopLevel/computeRoutes#StepsOverview
https://mantine.dev/core/accordion/
Icons from Tabler: https://tabler.io/docs/icons/react

## Views
<img width="368" alt="image" src="https://github.com/user-attachments/assets/505e2da4-b10f-48fa-b2b0-66f6719dc006">

